### PR TITLE
Make featured image use background size cover

### DIFF
--- a/css/large.css
+++ b/css/large.css
@@ -95,11 +95,6 @@ html {
 	height: 350px;
 }
 
-.image.feature {
-	width: 60%;
-	height: 350px; /* featured image is longer than others :) */
-}
-
 .news.feature {
 	width: 39%; /* there's a small space between image + news div so widths 39% + 60% (image div) used to prevent stacking of the divs one on top of the other */
 	vertical-align: top; /* needed for featured news div to be vertically aligned with featured image div */

--- a/index.php
+++ b/index.php
@@ -71,15 +71,14 @@
 		    	<div class="label"> <h2>News</h2> </div>
 		      	<div class="col s12 post">
 			        <!-- TODO: deal with how much content is outputted here, and making sure it's centered; problem is need vertical-align: top to keep news div in line with image div -->
-			        <!--div class="image feature"></div-->
               <?php
                 if ( has_post_thumbnail() ) {
-                  the_post_thumbnail(
-                    'post-thumbnail', ['class' => 'image feature', 'title' => 'Feature Post Thumbnail']);
+                  echo '<div class="image feature" style="background-image:url(' . get_the_post_thumbnail_url()
+                      . '"> </div>';
                 }
                 else {
-                    echo '<img class="image feature" src="' . get_bloginfo( 'stylesheet_directory' )
-                        . '/img/feature.jpeg" />';
+                  echo '<div class="image feature" style="background-image:url(' . get_bloginfo( 'stylesheet_directory' )
+                      . '/img/feature.jpeg)"></div>';
                 }
               ?>
 		        	<div class="news feature">

--- a/style.css
+++ b/style.css
@@ -90,6 +90,11 @@ iframe {
 	text-align: center;
 }
 
+.image.feature {
+  width: 60%;
+  background-size: cover;
+}
+
 .thumbnail {
   height: 400px;
   width: 300px;


### PR DESCRIPTION
The previous way we sized the featured post's thumbnail image did not preserve
the scale of the image. By using background size cover, the featured post's
thumbnail image now always has the correct scale and size.